### PR TITLE
Add HTMLUnescaper

### DIFF
--- a/internal/jsonutil/unescaper.go
+++ b/internal/jsonutil/unescaper.go
@@ -1,0 +1,69 @@
+package jsonutil
+
+import (
+	"bytes"
+	"io"
+)
+
+var (
+	leftAngle  = []byte("003c")
+	rightAngle = []byte("003e")
+	ampersand  = []byte("0026")
+)
+
+type HTMLUnescaper struct {
+	buf    []byte
+	offset int
+}
+
+func NewHTMLUnescaper(buf []byte) *HTMLUnescaper {
+	return &HTMLUnescaper{
+		buf: buf,
+	}
+}
+
+func (u *HTMLUnescaper) Read(b []byte) (int, error) {
+	n := 0
+
+	for i := 0; i < len(b); i++ {
+		if u.offset >= len(u.buf) {
+			return n, io.EOF
+		}
+
+		if len(u.buf)-u.offset < 6 {
+			b[i] = u.buf[u.offset]
+			n++
+			u.offset++
+			continue
+		}
+
+		sextet := u.buf[u.offset : u.offset+6]
+		if !bytes.HasPrefix(sextet, []byte(`\u`)) {
+			b[i] = u.buf[u.offset]
+			n++
+			u.offset++
+			continue
+		}
+
+		switch 0 {
+		case bytes.Compare(sextet[2:], leftAngle):
+			b[i] = '<'
+			n++
+			u.offset += 6
+		case bytes.Compare(sextet[2:], rightAngle):
+			b[i] = '>'
+			n++
+			u.offset += 6
+		case bytes.Compare(sextet[2:], ampersand):
+			b[i] = '&'
+			n++
+			u.offset += 6
+		default:
+			b[i] = u.buf[u.offset]
+			n++
+			u.offset++
+		}
+	}
+
+	return n, nil
+}

--- a/internal/jsonutil/unescaper.go
+++ b/internal/jsonutil/unescaper.go
@@ -5,10 +5,10 @@ import (
 	"io"
 )
 
-var escapeChars = map[byte]byte{
-	0x003c: '<',
-	0x003e: '>',
-	0x0026: '&',
+var escapeChars = map[string]byte{
+	"003c": '<',
+	"003e": '>',
+	"0026": '&',
 }
 
 type HTMLUnescaper struct {
@@ -73,7 +73,7 @@ func (u *HTMLUnescaper) Read(b []byte) (int, error) {
 		}
 
 		sextet := u.buf[u.offset : u.offset+6]
-		hexcode := sextet[2]<<3 | sextet[3]<<2 | sextet[4]<<1 | sextet[5]
+		hexcode := string(sextet[2:])
 
 		if char, ok := escapeChars[hexcode]; ok {
 			b[i] = char

--- a/internal/jsonutil/unescaper.go
+++ b/internal/jsonutil/unescaper.go
@@ -24,27 +24,55 @@ func NewHTMLUnescaper(buf []byte) *HTMLUnescaper {
 
 func (u *HTMLUnescaper) Read(b []byte) (int, error) {
 	n := 0
+	i := 0
 
-	for i := 0; i < len(b); i++ {
+	for i < len(b) {
 		if u.offset >= len(u.buf) {
 			return n, io.EOF
 		}
 
-		if len(u.buf)-u.offset < 6 {
-			b[i] = u.buf[u.offset]
-			n++
-			u.offset++
-			continue
+		if len(u.buf[u.offset:]) < 6 {
+			x := copy(b[i:], u.buf[u.offset:])
+			n += x
+			u.offset += x
+			goto done
+		}
+
+		j := bytes.Index(u.buf[u.offset:], []byte(`\u`))
+		if j == -1 {
+			// no escaped characters remaining in u.buf, just copy everything
+			x := copy(b[i:], u.buf[u.offset:])
+			n += x
+			u.offset += x
+			goto done
+		}
+
+		if j > 0 {
+			// escaped character is not the front of u.buf[u.offset:], copy
+			// everything up to it first
+			x := copy(b[i:], u.buf[u.offset:u.offset+j])
+			i += x
+			n += x
+			u.offset += x
+		}
+
+		if i >= len(b) {
+			// We've filled the destination buffer
+			goto done
+		}
+
+		if len(u.buf[u.offset:]) < 6 {
+			// even though we saw the beginning of an escape sequence, there's
+			// not even remaining characters to have a real escape sequence.
+			// this is a duplication of the block at the beginning of the copy
+			// loop
+			x := copy(b[i:], u.buf[u.offset:])
+			n += x
+			u.offset += x
+			goto done
 		}
 
 		sextet := u.buf[u.offset : u.offset+6]
-		if !bytes.HasPrefix(sextet, []byte(`\u`)) {
-			b[i] = u.buf[u.offset]
-			n++
-			u.offset++
-			continue
-		}
-
 		switch 0 {
 		case bytes.Compare(sextet[2:], leftAngle):
 			b[i] = '<'
@@ -59,10 +87,19 @@ func (u *HTMLUnescaper) Read(b []byte) (int, error) {
 			n++
 			u.offset += 6
 		default:
+			// Best we can do is take a single byte and go to the beginning of
+			// the loop to rescan for the next potential escape sequence
 			b[i] = u.buf[u.offset]
 			n++
 			u.offset++
 		}
+
+		i++
+	}
+
+done:
+	if u.offset >= len(u.buf) {
+		return n, io.EOF
 	}
 
 	return n, nil

--- a/internal/jsonutil/unescaper.go
+++ b/internal/jsonutil/unescaper.go
@@ -35,7 +35,7 @@ func (u *HTMLUnescaper) Read(b []byte) (int, error) {
 			x := copy(b[i:], u.buf[u.offset:])
 			n += x
 			u.offset += x
-			goto done
+			break
 		}
 
 		j := bytes.Index(u.buf[u.offset:], []byte(`\u`))
@@ -44,7 +44,7 @@ func (u *HTMLUnescaper) Read(b []byte) (int, error) {
 			x := copy(b[i:], u.buf[u.offset:])
 			n += x
 			u.offset += x
-			goto done
+			break
 		}
 
 		if j > 0 {
@@ -58,7 +58,7 @@ func (u *HTMLUnescaper) Read(b []byte) (int, error) {
 
 		if i >= len(b) {
 			// We've filled the destination buffer
-			goto done
+			break
 		}
 
 		if len(u.buf[u.offset:]) < 6 {
@@ -69,7 +69,7 @@ func (u *HTMLUnescaper) Read(b []byte) (int, error) {
 			x := copy(b[i:], u.buf[u.offset:])
 			n += x
 			u.offset += x
-			goto done
+			break
 		}
 
 		sextet := u.buf[u.offset : u.offset+6]
@@ -97,7 +97,6 @@ func (u *HTMLUnescaper) Read(b []byte) (int, error) {
 		i++
 	}
 
-done:
 	if u.offset >= len(u.buf) {
 		return n, io.EOF
 	}

--- a/internal/jsonutil/unescaper.go
+++ b/internal/jsonutil/unescaper.go
@@ -11,17 +11,28 @@ var escapeChars = map[string]byte{
 	"0026": '&',
 }
 
+// HTMLUnescaper provides an io.Reader implementation that does the inverse of
+// json.HTMLEscape as bytes are read off of it.
+//
+// N.B.: The current implementation only unescapes the <, >, and & characters.
+// The U+2028 and U+2029 characters remain escaped.
 type HTMLUnescaper struct {
 	buf    []byte
 	offset int
 }
 
+// NewHTMLUnescaper returns an HTMLUnescaper that unescapes bytes in buf when
+// read from. The HTMLUnescaper takes ownership of, but does not mutate, the
+// passed-in buffer; therefore callers may continue to use the original buffer
+// when they are finished using the unescaper.
 func NewHTMLUnescaper(buf []byte) *HTMLUnescaper {
 	return &HTMLUnescaper{
 		buf: buf,
 	}
 }
 
+// Read implements io.Reader, unescaping HTML-escaped characters as they are
+// read from the underlying buffer.
 func (u *HTMLUnescaper) Read(b []byte) (int, error) {
 	n := 0
 	i := 0

--- a/internal/jsonutil/unescaper_bench_test.go
+++ b/internal/jsonutil/unescaper_bench_test.go
@@ -1,0 +1,71 @@
+package jsonutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+)
+
+func listFiles(b *testing.B, dir string) []string {
+	entries, err := ioutil.ReadDir(dir)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	filenames := make([]string, 0, len(entries))
+	for _, f := range entries {
+		if f.IsDir() {
+			continue
+		}
+
+		filenames = append(filenames, f.Name())
+	}
+
+	return filenames
+}
+
+func BenchmarkHTMLUnescaper(b *testing.B) {
+	filenames := listFiles(b, "testdata")
+
+	for _, filename := range filenames {
+		b.Run(filename, func(b *testing.B) {
+			data, err := ioutil.ReadFile(filepath.Join("testdata", filename))
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			buf := bytes.NewBuffer(nil)
+			json.HTMLEscape(buf, data)
+			data = buf.Bytes()
+
+			b.ResetTimer()
+
+			b.Run("HTMLUnescaper", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					buf := bytes.NewBuffer(nil)
+					unescaper := NewHTMLUnescaper(data)
+					_, err := io.Copy(buf, unescaper)
+					if err != nil {
+						b.Error(err)
+					}
+				}
+			})
+
+			data2 := make([]byte, len(data))
+			copy(data2, data)
+
+			b.Run("io.Copy", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					buf := bytes.NewBuffer(nil)
+					_, err := io.Copy(buf, bytes.NewBuffer(data2))
+					if err != nil {
+						b.Error(err)
+					}
+				}
+			})
+		})
+	}
+}

--- a/internal/jsonutil/unescaper_test.go
+++ b/internal/jsonutil/unescaper_test.go
@@ -20,31 +20,28 @@ func TestHTMLUnescaper(t *testing.T) {
 			out: "trailing newline\n",
 		},
 		{
-			in:  "escaped \u003c",
+			in:  `escaped \u003c`,
 			out: "escaped <",
 		},
 		{
-			in:  "\u003c\u003e",
+			in:  `\u003c\u003e`,
 			out: "<>",
 		},
 		{
-			in:  "\u0010",
-			out: "\u0010",
+			in:  `\u0010`,
+			out: `\u0010`,
 		},
 	}
 
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.out, func(t *testing.T) {
+			e := NewHTMLUnescaper([]byte(tt.in))
 			buf := bytes.NewBuffer(nil)
-			buf.WriteString(tt.in)
+			io.Copy(buf, e)
 
-			e := NewHTMLUnescaper(buf.Bytes())
-			buf2 := bytes.NewBuffer(nil)
-			io.Copy(buf2, e)
-
-			out := buf2.String()
-			if out != tt.out {
+			out := buf.Bytes()
+			if bytes.Compare(out, []byte(tt.out)) != 0 {
 				t.Errorf("NewHTMLUnescaper(%s) got = %s want = %s", tt.in, out, tt.out)
 			}
 		})

--- a/internal/jsonutil/unescaper_test.go
+++ b/internal/jsonutil/unescaper_test.go
@@ -1,0 +1,52 @@
+package jsonutil
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestHTMLUnescaper(t *testing.T) {
+	tests := []struct {
+		in  string
+		out string
+	}{
+		{
+			in:  "hello",
+			out: "hello",
+		},
+		{
+			in:  "trailing newline\n",
+			out: "trailing newline\n",
+		},
+		{
+			in:  "escaped \u003c",
+			out: "escaped <",
+		},
+		{
+			in:  "\u003c\u003e",
+			out: "<>",
+		},
+		{
+			in:  "\u0010",
+			out: "\u0010",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.out, func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+			buf.WriteString(tt.in)
+
+			e := NewHTMLUnescaper(buf.Bytes())
+			buf2 := bytes.NewBuffer(nil)
+			io.Copy(buf2, e)
+
+			out := buf2.String()
+			if out != tt.out {
+				t.Errorf("NewHTMLUnescaper(%s) got = %s want = %s", tt.in, out, tt.out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In preparation for having `feature.Watch` also start detecting changes and persisting them back to the watched file. This deserves its own PR, though, so I'm separating the introduction of this type from its usage.

The tl;dr here is that `json.Marshal` unconditionally sets [`escapeHTML: true`](https://github.com/golang/go/blob/cca23a73733ff166722c69359f0bb45e12ccaa2b/src/encoding/json/encode.go#L161) and provides no way to consistently override that. You can use a `json.NewEncoder` and call `SetEscapeHTML(false)` on it before encoding, but any type that provides a custom `json.Marshaler` implementation will still end up with escaped HTML characters ([playground example](https://play.golang.org/p/ZIRVny8c2yG)).

Therefore, this adds an `io.Reader` to undo the effects of this escaping (mostly, I didn't care to handle the invisible characters `U+2028` or `U+2029`, but we can fix that later), explicitly so that when we write out a feature map as json, we don't turn expressions with comparison operators into HTML-escaped strings that aren't human-readable.

And ... it's not even that slow!! We're still within the same order of magnitude doing this unescaping as compared to simply calling `json.Marshal`:

```
goos: darwin
goarch: amd64
pkg: github.com/ajm188/go-ff/internal/jsonutil
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkHTMlUnescaperMarshal/large_file.json/json.Encode-8         	       4	 273275817 ns/op	105369256 B/op	 1748327 allocs/op
BenchmarkHTMlUnescaperMarshal/large_file.json/json.Marshal-8        	       4	 271569330 ns/op	129927066 B/op	 1748332 allocs/op
BenchmarkHTMlUnescaperMarshal/large_file.json/HTMLUnescaper-8       	       4	 319638787 ns/op	317468318 B/op	 1748387 allocs/op
```